### PR TITLE
fix: version no longer requires a v

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,9 +46,9 @@ runs:
     - name: Check if version string contains 'v' and strip it out
       shell: bash
       run: |
-        RAW_VERSION=${{ inputs.version }};
-        if [ "${RAW_VERSION#*v}" != "$RAW_VERSION" ]; then
-          echo "VERSION=${RAW_VERSION#*v}" >> $GITHUB_ENV;
+        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV;
+        if [ "${VERSION#*v}" != "$VERSION" ]; then
+          echo "VERSION=${VERSION#*v}" >> $GITHUB_ENV;
         fi
 
     - name: Create or update changelog


### PR DESCRIPTION
Fixes some faulty logic I overlooked the first time :sweat_smile: The step that was meant to strip the "v" from the version, if it exists, was actually only setting the correct variable when the "v" was present. 